### PR TITLE
Change metadata properties to be placed in the JSON API meta object instead of using a suffix

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -445,9 +445,9 @@ For example, the following query can be sent to API implementations `exmpl1` and
 Metadata properties
 -------------------
 
-A metadata property represents property-specific metadata for each entry.
-How these are communicated in the response depend on the response format.
-For the JSON response format, the resource object metadata field is used, see `JSON Response Schema: Common Fields`_.
+A metadata property represents property-specific metadata for a given entry.
+How these are communicated in the response depends on the response format.
+For the JSON response format, the resource object metadata field, :field:`meta`, is used, see `JSON Response Schema: Common Fields`_.
 
 The metadata property is a dictionary of format specified by the field :field:`x-optimade-metadata-definition` in the Property Definition of the field, see `Property Definitions`_.
 Database providers are allowed to define their own metadata properties in :field:`x-optimade-metadata-definition`, but they MUST use the database-specific prefix even for metadata for database-specific fields.

--- a/optimade.rst
+++ b/optimade.rst
@@ -690,7 +690,7 @@ Every response SHOULD contain the following fields, and MUST contain at least :f
 - **data**: The schema of this value varies by endpoint, it can be either a *single* `JSON API resource object <http://jsonapi.org/format/1.0/#document-resource-objects>`__ or a *list* of JSON API resource objects.
   Every resource object needs the :field:`type` and :field:`id` fields, and its attributes (described in section `API Endpoints`_) need to be in a dictionary corresponding to the :field:`attributes` field.
   Each resource object MAY contain a :field:`meta` field used to communicate `Metadata properties`_.
-  The keys of the :field:`meta` field give the names of the data fields in :field:`attributes` they provide metadata for and the corresponding values are metadata property objects.
+  The keys of the :field:`meta` field are the names of the respective data fields in :field:`attributes` that they provide metadata for, and the corresponding values are metadata property objects.
 
 The response MAY also return resources related to the primary data in the field:
 
@@ -1014,7 +1014,8 @@ OPTIONALLY it can also contain the following fields:
 
   - **self**: the entry's URL
 
-- **meta**: a `JSON API meta object <https://jsonapi.org/format/1.0/#document-meta>`__ that contains non-standard meta-information about the object.
+- **meta**: a `JSON API meta object <https://jsonapi.org/format/1.0/#document-meta>`__ that is used to communicate `Metadata properties`_.
+  The keys of the :field:`meta` field are the names of the respective data fields in :field:`attributes` that they provide metadata for, and the corresponding values are metadata property objects.
 
 - **relationships**: a dictionary containing references to other entries according to the description in section `Relationships`_ encoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.
   The OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary of the JSON API resource identifier object.

--- a/optimade.rst
+++ b/optimade.rst
@@ -449,7 +449,7 @@ A metadata property represents property-specific metadata for a given entry.
 How these are communicated in the response depends on the response format.
 For the JSON response format, the resource object metadata field, :field:`meta`, is used, see `JSON Response Schema: Common Fields`_.
 
-The metadata property is a dictionary of format specified by the field :field:`x-optimade-metadata-definition` in the Property Definition of the field, see `Property Definitions`_.
+The metadata property is a dictionary in the format specified by the field :field:`x-optimade-metadata-definition` in the Property Definition of the field, see `Property Definitions`_.
 Database providers are allowed to define their own metadata properties in :field:`x-optimade-metadata-definition`, but they MUST use the database-specific prefix even for metadata for database-specific fields.
 For example, the metadata property definition of the field :field:`_exmpl_example_field` MUST NOT define a metadata field named, e.g., :field:`accuracy`; the field rather needs to be named, e.g., :field:`_exmpl_accuracy`.
 The reason for this limitation is to avoid name collisions with standard metadata fields defined by the OPTIMADE standard that apply also to database-specific data fields.
@@ -493,7 +493,7 @@ Example of a response using the JSON response format with two structure entries 
        // ...
      }
 
-Example of the corresponding metadata property definition to be placed in the field :field:`x-optimade-metadata-definition` in the property definition of :field:`element_ratios`:
+Example of the corresponding metadata property definition contained in the field :field:`x-optimade-metadata-definition` which is placed in the property definition of :field:`element_ratios`:
 
     .. code:: jsonc
          // ...
@@ -1972,7 +1972,7 @@ A Property Definition MUST be composed according to the combination of the requi
 **OPTIONAL keys for the outermost level of the Property Definition:**
 
 - :field:`x-optimade-metadata-definition`: Dictionary.
-  A dictionary that is itself a property definition which defines the format of the metadata dictionary for this field.
+  A dictionary that is itself a property definition, which defines the format of the metadata dictionary for this field.
   The :field:`x-optimade-metadata-definition` field SHOULD not include another :field:`x-optimade-metadata-definition` field.
 
 **REQUIRED keys for all levels of the Property Definition:**

--- a/optimade.rst
+++ b/optimade.rst
@@ -450,8 +450,8 @@ How these are communicated in the response depend on the response format.
 For the JSON response format, the resource object metadata field is used, see `JSON Response Schema: Common Fields`_.
 
 The metadata property is a dictionary of format specified by the field :field:`x-optimade-metadata-definition` in the Property Definition of the field, see `Property Definitions`_.
-Database providers are allowed to define their own metadata properties in :field:`x-optimade-metadata-definition`, but the MUST use the database-specific prefix even for metadata for database-specific fields.
-For example, the metadata property definition of the field :field:`_exmpl_example_field` MUST NOT define a metadata field named, e.g., :field:`accuracy`, but rather need to be name the field, e.g., :field:`_exmpl_accuracy`.
+Database providers are allowed to define their own metadata properties in :field:`x-optimade-metadata-definition`, but they MUST use the database-specific prefix even for metadata for database-specific fields.
+For example, the metadata property definition of the field :field:`_exmpl_example_field` MUST NOT define a metadata field named, e.g., :field:`accuracy`; the field rather needs to be named, e.g., :field:`_exmpl_accuracy`.
 The reason for this limitation is to avoid name collisions with standard metadata fields defined by the OPTIMADE standard that apply also to database-specific data fields.
 
 If an implementation supports the metadata field, it SHOULD return the metadata field whenever the property to which the metadata field belongs is returned.
@@ -493,7 +493,7 @@ Example of a response using the JSON response format with two structure entries 
        // ...
      }
 
-Example of the corresponding metadata property definition for :field:`element_ratios` to place in the field :field:`x-optimade-metadata-definition` in the property definition of :field:`element_ratios`:
+Example of the corresponding metadata property definition to be placed in the field :field:`x-optimade-metadata-definition` in the property definition of :field:`element_ratios`:
 
     .. code:: jsonc
          // ...


### PR DESCRIPTION
This tries to implement the end proposed result based on the discussion in today's web meeting.
I thought it was best to just get this down into text before we forgot.

Note that this is a PR against @JPBergsma's repo for the branch he is PR:ing to merge into the OPTIMADE devel branch.

This link gives a more direct comparison between OPTIMADE develop and the present proposed change:

https://github.com/Materials-Consortia/OPTIMADE/compare/develop...rartino:JPBergsma_add_meta